### PR TITLE
fixup! override __cxa_guard_* without '-wrap'

### DIFF
--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -147,9 +147,7 @@ LINKFLAGS += -T$(RIOTCPU)/$(CPU)/ld/esp32.rom.nanofmt.ld
 LINKFLAGS += -nostdlib -lgcc -Wl,-gc-sections
 
 ifneq (,$(filter esp_cxx,$(USEMODULE)))
-    LINKFLAGS += -Wl,-wrap,__cxa_guard_acquire
-    LINKFLAGS += -Wl,-wrap,__cxa_guard_release
-    LINKFLAGS += -Wl,-wrap,__cxa_guard_abort
+    UNDEF += $(BINDIR)/esp_cxx/cxa_guard.o
 endif
 
 # The ELFFILE is the base one used for flashing

--- a/cpu/esp32/cxx/cxa_guard.cpp
+++ b/cpu/esp32/cxx/cxa_guard.cpp
@@ -55,7 +55,7 @@ typedef struct {
 namespace __cxxabiv1
 {
     extern "C"
-    int __wrap___cxa_guard_acquire (__guard *g)
+    int __cxa_guard_acquire (__guard *g)
     {
         guard_t *_gt = (guard_t *)g;
 
@@ -83,7 +83,7 @@ namespace __cxxabiv1
     }
 
     extern "C"
-    void __wrap___cxa_guard_release (__guard *g)
+    void __cxa_guard_release (__guard *g)
     {
         guard_t *_gt = (guard_t *)g;
 
@@ -99,7 +99,7 @@ namespace __cxxabiv1
     }
 
     extern "C"
-    void __wrap___cxa_guard_abort (__guard *g)
+    void __cxa_guard_abort (__guard *g)
     {
         guard_t *_gt = (guard_t *)g;
 


### PR DESCRIPTION
### Contribution description

I managed to directly override the symbols by using UNDEF. That they are overrided can be verified by objdump-ing the cpp_tests binary.

```
400d0020 <__cxa_guard_acquire>:
400d0020:	004136        	entry	a1, 32
400d0023:	000232        	l8ui	a3, a2, 0
400d0026:	00a082        	movi	a8, 0
400d0029:	259387        	bne	a3, a8, 400d0052 <__cxa_guard_acquire+0x32>
400d002c:	b06b65        	call8	400806e4 <irq_disable>
400d002f:	010282        	l8ui	a8, a2, 1
400d0032:	203aa0        	or	a3, a10, a10
400d0035:	00d816        	beqz	a8, 400d0046 <__cxa_guard_acquire+0x26>
400d0038:	b06c65        	call8	40080700 <irq_restore>
400d003b:	fff7c1        	l32r	a12, 400d0018 <_flash_cache_start>
400d003e:	fff7b1        	l32r	a11, 400d001c <_flash_cache_start+0x4>
400d0041:	1a0c      	movi.n	a10, 1
400d0043:	b22ee5        	call8	40082330 <log_write_tagged>
400d0046:	180c      	movi.n	a8, 1
400d0048:	014282        	s8i	a8, a2, 1
400d004b:	03ad      	mov.n	a10, a3
400d004d:	b06b25        	call8	40080700 <irq_restore>
400d0050:	180c      	movi.n	a8, 1
400d0052:	082d      	mov.n	a2, a8
400d0054:	f01d      	retw.n
	...
```